### PR TITLE
Develop

### DIFF
--- a/cairis/cairis/CanonicalModelViewer.py
+++ b/cairis/cairis/CanonicalModelViewer.py
@@ -158,7 +158,8 @@ class CanonicalModelViewer(kaosxdot.KaosDotWindow):
       self.unblockHandlers()
       self.widget.zoom_to_fit()
     except ARMException,errorText:
-      if isinstance(errorText.value, DatabaseProxyException):
+      if hasattr(errorText, 'value'):
+        if isinstance(errorText.value, DatabaseProxyException):
           print(errorText.value.value)
       else:
           print str(errorText)

--- a/cairis/cairis/CanonicalModelViewer.py
+++ b/cairis/cairis/CanonicalModelViewer.py
@@ -158,7 +158,10 @@ class CanonicalModelViewer(kaosxdot.KaosDotWindow):
       self.unblockHandlers()
       self.widget.zoom_to_fit()
     except ARMException,errorText:
-      print str(errorText)
+      if isinstance(errorText.value, DatabaseProxyException):
+          print(errorText.value.value)
+      else:
+          print str(errorText)
 #      dlg = wx.MessageDialog(self,str(errorText),'IRIS',wx.OK | wx.ICON_ERROR)
 #      dlg.ShowModal()
 #      dlg.Destroy()


### PR DESCRIPTION
Improves error reporting by looking in the ARMException to see if the underlying exception is a DatabaseProxyException and then using the message included in the DatabaseProxyException to display the actual error. Without this code the error displayed in the terminal would just be 'DatabaseProxyException()'.