### PR TITLE
Tweak asset example for swagger hub

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -12283,7 +12283,7 @@
             },
             "description" : "Environment specific asset properties",
             "example" : [ {
-              "theName" : "Psychosis",
+              "theEnvironmentName" : "Psychosis",
               "theAssociations" : [ [ "0", "Association", "*", "", "", "*", 0, "Workflow" ] ],
               "theProperties" : [ {
                 "name" : "Confidentiality",


### PR DESCRIPTION
Ensure that the swagger hub asset example shows theEnvironementName rather than theName